### PR TITLE
Replace schemes with globals

### DIFF
--- a/widgets/elementor/author-box.php
+++ b/widgets/elementor/author-box.php
@@ -12,8 +12,8 @@ namespace ConeBlogWidgets\Widgets;
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use ConeBlogWidgets\Classes\Helper;
 
 // Security Note: Blocks direct access to the plugin PHP files.
@@ -492,7 +492,9 @@ class coneblog_Author_Box extends Widget_Base {
             [
                 'name' => 'coneblog_authorbox_name',
                 'label' => __('Author Name', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' => '{{WRAPPER}} .cb-author-name h3',
 				'fields_options' => [
 					'typography' => ['default' => 'yes'],
@@ -508,7 +510,9 @@ class coneblog_Author_Box extends Widget_Base {
             [
                 'name' => 'coneblog_authorbox_name_2',
                 'label' => __('Author Name', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' => '{{WRAPPER}} .cb-author-name h3',
 				'fields_options' => [
 					'typography' => ['default' => 'yes'],
@@ -536,7 +540,9 @@ class coneblog_Author_Box extends Widget_Base {
             [
                 'name' => 'coneblog_authorbox_title',
                 'label' => __('Author Title', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_3,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
                 'selectors' => [
 					'{{WRAPPER}} .cb-author-title',
 					'{{WRAPPER}} .cb-author-title a',
@@ -577,7 +583,9 @@ class coneblog_Author_Box extends Widget_Base {
             [
                 'name' => 'coneblog_authorbox_bio',
                 'label' => __('Author Bio', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_3,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_TEXT,
+				],
                 'selector' => '{{WRAPPER}} .cb-author-bio p',
 				'fields_options' => [
 					'typography' => ['default' => 'yes'],
@@ -641,9 +649,8 @@ class coneblog_Author_Box extends Widget_Base {
 			[
 				'label' => __( 'Hover Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .coneblog-author-box:hover .cb-avatar img' => 'border-color: {{VALUE}}',
@@ -729,9 +736,8 @@ class coneblog_Author_Box extends Widget_Base {
 			[
 				'label' => __( 'Icon Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .cb-social-links ul li a' => 'color: {{VALUE}}',
@@ -744,9 +750,8 @@ class coneblog_Author_Box extends Widget_Base {
 			[
 				'label' => __( 'Icon Hover Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .cb-social-links ul li a:hover' => 'color: {{VALUE}}',
@@ -819,9 +824,8 @@ class coneblog_Author_Box extends Widget_Base {
 			[
 				'label' => __( 'Text Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .cb-author-posts a' => 'color: {{VALUE}}',
@@ -834,9 +838,8 @@ class coneblog_Author_Box extends Widget_Base {
 			[
 				'label' => __( 'Background Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .cb-author-posts a' => 'background-color: {{VALUE}}',
@@ -849,9 +852,8 @@ class coneblog_Author_Box extends Widget_Base {
 			[
 				'label' => __( 'Hover Text Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .cb-author-posts a:hover' => 'color: {{VALUE}}',
@@ -864,9 +866,8 @@ class coneblog_Author_Box extends Widget_Base {
 			[
 				'label' => __( 'Hover Background Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .cb-author-posts a:hover' => 'background-color: {{VALUE}}',

--- a/widgets/elementor/category-tiles.php
+++ b/widgets/elementor/category-tiles.php
@@ -12,8 +12,7 @@ namespace ConeBlogWidgets\Widgets;
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use ConeBlogWidgets\Classes\Helper;
 
 // Security Note: Blocks direct access to the plugin PHP files.
@@ -441,7 +440,9 @@ class coneblog_Category_Tiles extends Widget_Base {
             [
                 'name' => 'coneblog_tile_title_typography',
                 'label' => __('Category Name', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],	
                 'selector' =>
 					'{{WRAPPER}} .coneblog-category-tile-link',
             ]

--- a/widgets/elementor/news-ticker.php
+++ b/widgets/elementor/news-ticker.php
@@ -12,8 +12,8 @@ namespace ConeBlogWidgets\Widgets;
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use ConeBlogWidgets\Classes\Helper;
 
 // Security Note: Blocks direct access to the plugin PHP files.
@@ -389,7 +389,9 @@ class coneblog_News_Ticker extends Widget_Base {
             [
                 'name' => 'coneblog_news_ticker_title_typography',
                 'label' => __('News Title', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .coneblog-ticker .item .news-title h3',
             ]
@@ -424,7 +426,9 @@ class coneblog_News_Ticker extends Widget_Base {
             [
                 'name' => 'coneblog_news_ticker_meta_typography',
                 'label' => __('News Meta', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_2,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
                 'selector' => '{{WRAPPER}} .coneblog-ticker .item .news-meta > span',
             ]
         );
@@ -458,9 +462,8 @@ class coneblog_News_Ticker extends Widget_Base {
 			[
 				'label' => __( 'Label Background', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .coneblog-news-ticker .ticekr-label' => 'background-color: {{VALUE}}',
@@ -473,9 +476,8 @@ class coneblog_News_Ticker extends Widget_Base {
 			[
 				'label' => __( 'Label Text', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .coneblog-news-ticker .ticekr-label' => 'color: {{VALUE}}',
@@ -488,9 +490,8 @@ class coneblog_News_Ticker extends Widget_Base {
 			[
 				'label' => __( 'Ticker Body Background', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .coneblog-news-ticker .coneblog-ticker' => 'background-color: {{VALUE}}',
@@ -535,9 +536,8 @@ class coneblog_News_Ticker extends Widget_Base {
 			[
 				'label' => __( 'Icon Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-ticker .owl-prev' => 'color: {{VALUE}} !important',
@@ -551,9 +551,8 @@ class coneblog_News_Ticker extends Widget_Base {
 			[
 				'label' => __( 'Background Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-ticker .owl-prev' => 'background: {{VALUE}} !important',
@@ -576,9 +575,8 @@ class coneblog_News_Ticker extends Widget_Base {
 			[
 				'label' => __( 'Icon Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-ticker .owl-prev:hover' => 'color: {{VALUE}} !important',
@@ -592,9 +590,8 @@ class coneblog_News_Ticker extends Widget_Base {
 			[
 				'label' => __( 'Background Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-ticker .owl-prev:hover' => 'background: {{VALUE}} !important',

--- a/widgets/elementor/posts-carousel.php
+++ b/widgets/elementor/posts-carousel.php
@@ -12,8 +12,8 @@ namespace ConeBlogWidgets\Widgets;
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use ConeBlogWidgets\Classes\Helper;
 
 // Security Note: Blocks direct access to the plugin PHP files.
@@ -650,7 +650,9 @@ class coneblog_Carousel_Posts extends Widget_Base {
             [
                 'name' => 'coneblog_widget_heading_typography',
                 'label' => __('Widget Head Typography', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .coneblog-widget-head h3',
             ]
@@ -766,7 +768,9 @@ class coneblog_Carousel_Posts extends Widget_Base {
             [
                 'name' => 'coneblog_post_list_title_typography',
                 'label' => __('Post Title', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .coneblog-posts-carousel .coneblog-carousel .item h3',
             ]
@@ -799,7 +803,9 @@ class coneblog_Carousel_Posts extends Widget_Base {
             [
                 'name' => 'coneblog_post_list_title_typography_2',
                 'label' => __('Post Excerpt', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_2,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
                 'selector' => '{{WRAPPER}} .coneblog-posts-carousel .coneblog-carousel .item .post-desc',
             ]
         );
@@ -828,9 +834,8 @@ class coneblog_Carousel_Posts extends Widget_Base {
 			[
 				'label' => __( 'Term Name Background', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .grid-post-term span.term-name' => 'background-color: {{VALUE}}',
@@ -843,9 +848,8 @@ class coneblog_Carousel_Posts extends Widget_Base {
 			[
 				'label' => __( 'Term Name Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .grid-post-term span.term-name' => 'color: {{VALUE}}',
@@ -858,7 +862,9 @@ class coneblog_Carousel_Posts extends Widget_Base {
             [
                 'name' => 'coneblog_post_term_typography',
                 'label' => __('Typography', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .grid-post-term span.term-name',
             ]
@@ -918,9 +924,8 @@ class coneblog_Carousel_Posts extends Widget_Base {
 			[
 				'label' => __( 'Icon Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-carousel .owl-prev' => 'color: {{VALUE}} !important',
@@ -934,9 +939,8 @@ class coneblog_Carousel_Posts extends Widget_Base {
 			[
 				'label' => __( 'Background Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-carousel .owl-prev' => 'background: {{VALUE}} !important',
@@ -959,9 +963,8 @@ class coneblog_Carousel_Posts extends Widget_Base {
 			[
 				'label' => __( 'Icon Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-carousel .owl-prev:hover' => 'color: {{VALUE}} !important',
@@ -975,9 +978,8 @@ class coneblog_Carousel_Posts extends Widget_Base {
 			[
 				'label' => __( 'Background Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-carousel .owl-prev:hover' => 'background: {{VALUE}} !important',
@@ -1039,9 +1041,8 @@ class coneblog_Carousel_Posts extends Widget_Base {
 			[
 				'label' => __( 'Dot Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-carousel .owl-dot' => 'background-color: {{VALUE}}',
@@ -1054,9 +1055,8 @@ class coneblog_Carousel_Posts extends Widget_Base {
 			[
 				'label' => __( 'Dot Active/Hover', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-carousel .owl-dot:hover' => 'background-color: {{VALUE}}',

--- a/widgets/elementor/posts-classic.php
+++ b/widgets/elementor/posts-classic.php
@@ -12,8 +12,8 @@ namespace ConeBlogWidgets\Widgets;
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use ConeBlogWidgets\Classes\Helper;
 
 // Security Note: Blocks direct access to the plugin PHP files.
@@ -412,7 +412,9 @@ class coneblog_Classic_Posts extends Widget_Base {
             [
                 'name' => 'coneblog_widget_heading_typography',
                 'label' => __('Widget Head Typography', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .coneblog-widget-head h3',
             ]
@@ -442,7 +444,9 @@ class coneblog_Classic_Posts extends Widget_Base {
             [
                 'name' => 'coneblog_post_list_widget_head_typography',
                 'label' => __('Typography', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .coneblog-widget-head h3',
             ]
@@ -526,7 +530,9 @@ class coneblog_Classic_Posts extends Widget_Base {
             [
                 'name' => 'coneblog_post_list_title_large_typography',
                 'label' => __('Post Title (Large Grid)', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .coneblog-posts-classic .item-1 .item-meta .post-title',
             ]
@@ -536,7 +542,9 @@ class coneblog_Classic_Posts extends Widget_Base {
             [
                 'name' => 'coneblog_post_list_title_typography',
                 'label' => __('Post Title (Small Grids)', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .coneblog-posts-classic .item-meta .post-title',
             ]
@@ -546,7 +554,9 @@ class coneblog_Classic_Posts extends Widget_Base {
             [
                 'name' => 'coneblog_post_list_title_typography_2',
                 'label' => __('Post Excerpt', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_2,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
                 'selector' => '{{WRAPPER}} .coneblog-posts-classic .item-meta .post-desc',
             ]
         );
@@ -575,9 +585,8 @@ class coneblog_Classic_Posts extends Widget_Base {
 			[
 				'label' => __( 'Term Name Background', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .grid-post-term span.term-name' => 'background-color: {{VALUE}}',
@@ -590,9 +599,8 @@ class coneblog_Classic_Posts extends Widget_Base {
 			[
 				'label' => __( 'Term Name Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .grid-post-term span.term-name' => 'color: {{VALUE}}',
@@ -605,7 +613,9 @@ class coneblog_Classic_Posts extends Widget_Base {
             [
                 'name' => 'coneblog_post_term_typography',
                 'label' => __('Typography', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .grid-post-term span.term-name',
             ]

--- a/widgets/elementor/posts-grid.php
+++ b/widgets/elementor/posts-grid.php
@@ -12,8 +12,8 @@ namespace ConeBlogWidgets\Widgets;
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use ConeBlogWidgets\Classes\Helper;
 
 // Security Note: Blocks direct access to the plugin PHP files.
@@ -380,7 +380,9 @@ class STBFeaturedGrid extends Widget_Base {
             [
                 'name' => 'coneblog_post_grid_title_typography',
                 'label' => __('Typography (Large Grids)', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .featured-grid-layout-1 .featured-grid-item.grid-item-1 .featured-meta-inner h3 a, {{WRAPPER}} .featured-grid-layout-2  .featured-grid-item.grid-item-1 .featured-meta-inner h3 a, {{WRAPPER}} .featured-grid-layout-4  .featured-grid-item.grid-item-1 .featured-meta-inner h3 a',
             ]
@@ -390,7 +392,9 @@ class STBFeaturedGrid extends Widget_Base {
             [
                 'name' => 'coneblog_post_grid_title_typography_2',
                 'label' => __('Typography (Small Grids)', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_2,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
                 'selector' => '{{WRAPPER}} .featured-grid-item.small-grid .featured-meta-inner h3, {{WRAPPER}} .featured-grid-item.small-grid .featured-meta-inner h3 a, {{WRAPPER}} .featured-grid-layout-6 .featured-grid-item .featured-meta-inner h3 a',
             ]
         );
@@ -429,9 +433,8 @@ class STBFeaturedGrid extends Widget_Base {
 			[
 				'label' => __( 'Overlay Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .featured-grid-item .overlay' => 'background: {{VALUE}}',
@@ -445,9 +448,8 @@ class STBFeaturedGrid extends Widget_Base {
 			[
 				'label' => __( 'Overlay (Hover) Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .featured-grid-item:hover .overlay' => 'background: {{VALUE}}',
@@ -511,9 +513,8 @@ class STBFeaturedGrid extends Widget_Base {
 			[
 				'label' => __( 'Term Name Background', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .grid-post-term span.term-name' => 'background-color: {{VALUE}}',
@@ -526,9 +527,8 @@ class STBFeaturedGrid extends Widget_Base {
 			[
 				'label' => __( 'Term Name Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .grid-post-term span.term-name' => 'color: {{VALUE}}',
@@ -541,7 +541,9 @@ class STBFeaturedGrid extends Widget_Base {
             [
                 'name' => 'coneblog_post_term_typography',
                 'label' => __('Typography', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .grid-post-term span.term-name',
             ]

--- a/widgets/elementor/posts-list.php
+++ b/widgets/elementor/posts-list.php
@@ -12,8 +12,8 @@ namespace ConeBlogWidgets\Widgets;
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use ConeBlogWidgets\Classes\Helper;
 
 // Security Note: Blocks direct access to the plugin PHP files.
@@ -441,7 +441,9 @@ class coneblog_Posts_List extends Widget_Base {
             [
                 'name' => 'coneblog_widget_heading_typography',
                 'label' => __('Widget Head Typography', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .coneblog-widget-head h3',
             ]
@@ -564,7 +566,9 @@ class coneblog_Posts_List extends Widget_Base {
             [
                 'name' => 'coneblog_post_list_title_typography',
                 'label' => __('Post Title', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .coneblog-posts-list .item-meta .post-title',
             ]
@@ -574,7 +578,9 @@ class coneblog_Posts_List extends Widget_Base {
             [
                 'name' => 'coneblog_post_list_title_typography_2',
                 'label' => __('Post Excerpt', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_2,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
                 'selector' => '{{WRAPPER}} .coneblog-posts-list .item-meta .post-desc',
             ]
         );
@@ -603,9 +609,8 @@ class coneblog_Posts_List extends Widget_Base {
 			[
 				'label' => __( 'Term Name Background', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .grid-post-term span.term-name' => 'background-color: {{VALUE}}',
@@ -618,9 +623,8 @@ class coneblog_Posts_List extends Widget_Base {
 			[
 				'label' => __( 'Term Name Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .grid-post-term span.term-name' => 'color: {{VALUE}}',
@@ -633,7 +637,9 @@ class coneblog_Posts_List extends Widget_Base {
             [
                 'name' => 'coneblog_post_term_typography',
                 'label' => __('Typography', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .grid-post-term span.term-name',
             ]

--- a/widgets/elementor/posts-slider.php
+++ b/widgets/elementor/posts-slider.php
@@ -12,8 +12,8 @@ namespace ConeBlogWidgets\Widgets;
 use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Typography;
-use Elementor\Core\Schemes\Typography;
-use Elementor\Core\Schemes\Color;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use ConeBlogWidgets\Classes\Helper;
 
 // Security Note: Blocks direct access to the plugin PHP files.
@@ -521,7 +521,9 @@ class coneblog_Slider_Posts extends Widget_Base {
             [
                 'name' => 'coneblog_post_list_title_typography',
                 'label' => __('Post Title', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .coneblog-posts-slider .coneblog-slider .item .item-meta h3 a',
             ]
@@ -556,7 +558,9 @@ class coneblog_Slider_Posts extends Widget_Base {
             [
                 'name' => 'coneblog_post_list_title_typography_2',
                 'label' => __('Post Excerpt', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_2,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_SECONDARY,
+				],
                 'selector' => '{{WRAPPER}} .coneblog-posts-slider .coneblog-slider .item .post-desc',
             ]
         );
@@ -586,9 +590,8 @@ class coneblog_Slider_Posts extends Widget_Base {
 			[
 				'label' => __( 'Term Name Background', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .grid-post-term span.term-name' => 'background-color: {{VALUE}}',
@@ -601,9 +604,8 @@ class coneblog_Slider_Posts extends Widget_Base {
 			[
 				'label' => __( 'Term Name Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
 					'{{WRAPPER}} .grid-post-term span.term-name' => 'color: {{VALUE}}',
@@ -616,7 +618,9 @@ class coneblog_Slider_Posts extends Widget_Base {
             [
                 'name' => 'coneblog_post_term_typography',
                 'label' => __('Typography', 'coneblog-widgets'),
-                'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
                 'selector' =>
 					'{{WRAPPER}} .grid-post-term span.term-name',
             ]
@@ -676,9 +680,8 @@ class coneblog_Slider_Posts extends Widget_Base {
 			[
 				'label' => __( 'Icon Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-slider .owl-prev' => 'color: {{VALUE}} !important',
@@ -692,9 +695,8 @@ class coneblog_Slider_Posts extends Widget_Base {
 			[
 				'label' => __( 'Background Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-slider .owl-prev' => 'background: {{VALUE}} !important',
@@ -717,9 +719,8 @@ class coneblog_Slider_Posts extends Widget_Base {
 			[
 				'label' => __( 'Icon Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-slider .owl-prev:hover' => 'color: {{VALUE}} !important',
@@ -733,9 +734,8 @@ class coneblog_Slider_Posts extends Widget_Base {
 			[
 				'label' => __( 'Background Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-slider .owl-prev:hover' => 'background: {{VALUE}} !important',
@@ -797,9 +797,8 @@ class coneblog_Slider_Posts extends Widget_Base {
 			[
 				'label' => __( 'Dot Color', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-slider .owl-dot' => 'background-color: {{VALUE}}',
@@ -812,9 +811,8 @@ class coneblog_Slider_Posts extends Widget_Base {
 			[
 				'label' => __( 'Dot Active/Hover', 'coneblog-widgets' ),
 				'type' => \Elementor\Controls_Manager::COLOR,
-				'scheme' => [
-					'type' => Color::get_type(),
-					'value' => Color::COLOR_1,
+				'global' => [
+					'default' => Global_Colors::COLOR_PRIMARY,
 				],
 				'selectors' => [
                     '{{WRAPPER}} .coneblog-slider .owl-dot:hover' => 'background-color: {{VALUE}}',


### PR DESCRIPTION
The plugin is using the deprecated "**Schemes**" mechanism that had been replaced with "**Globals**" in Elementor 3.0.0 (released in 2020).

Ref: https://developers.elementor.com/docs/deprecations/complex-example/