### PR TITLE
Use new naming convention for widget methods

### DIFF
--- a/widgets/elementor/author-box.php
+++ b/widgets/elementor/author-box.php
@@ -112,7 +112,7 @@ class coneblog_Author_Box extends Widget_Base {
 	 *
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 
 		/**
 		 * The Layout Tab

--- a/widgets/elementor/category-tiles.php
+++ b/widgets/elementor/category-tiles.php
@@ -112,7 +112,7 @@ class coneblog_Category_Tiles extends Widget_Base {
 	 *
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 		$post_types = Helper::coneblog_get_post_types();
 		$categories = Helper::coneblog_get_categories();
 		//var_dump($categories);

--- a/widgets/elementor/news-ticker.php
+++ b/widgets/elementor/news-ticker.php
@@ -112,7 +112,7 @@ class coneblog_News_Ticker extends Widget_Base {
 	 *
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 		$post_types = Helper::coneblog_get_post_types();
 		$taxonomies = get_taxonomies([], 'objects');
 

--- a/widgets/elementor/posts-carousel.php
+++ b/widgets/elementor/posts-carousel.php
@@ -112,7 +112,7 @@ class coneblog_Carousel_Posts extends Widget_Base {
 	 *
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 		$post_types = Helper::coneblog_get_post_types();
 		$taxonomies = get_taxonomies([], 'objects');
 

--- a/widgets/elementor/posts-classic.php
+++ b/widgets/elementor/posts-classic.php
@@ -112,7 +112,7 @@ class coneblog_Classic_Posts extends Widget_Base {
 	 *
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 		$post_types = Helper::coneblog_get_post_types();
 		$taxonomies = get_taxonomies([], 'objects');
 

--- a/widgets/elementor/posts-grid.php
+++ b/widgets/elementor/posts-grid.php
@@ -112,7 +112,7 @@ class STBFeaturedGrid extends Widget_Base {
 	 *
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 		$post_types = Helper::coneblog_get_post_types();
 		$taxonomies = get_taxonomies([], 'objects');
 

--- a/widgets/elementor/posts-list.php
+++ b/widgets/elementor/posts-list.php
@@ -112,7 +112,7 @@ class coneblog_Posts_List extends Widget_Base {
 	 *
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 		$post_types = Helper::coneblog_get_post_types();
 		$taxonomies = get_taxonomies([], 'objects');
 

--- a/widgets/elementor/posts-slider.php
+++ b/widgets/elementor/posts-slider.php
@@ -112,7 +112,7 @@ class coneblog_Slider_Posts extends Widget_Base {
 	 *
 	 * @access protected
 	 */
-	protected function _register_controls() {
+	protected function register_controls() {
 		$post_types = Helper::coneblog_get_post_types();
 		$taxonomies = get_taxonomies([], 'objects');
 


### PR DESCRIPTION
Elementor no longer uses `_register_controls()`, it should be replaced with `register_controls()`.

See this dev doc: https://developers.elementor.com/docs/deprecations/simple-example/

